### PR TITLE
Added some usefull derives for 'SpeechSynthesisOutputFormat'

### DIFF
--- a/src/common/speech_synthesis_output_format.rs
+++ b/src/common/speech_synthesis_output_format.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 /// SpeechSynthesisOutputFormat defines the possible speech synthesis output audio formats.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum SpeechSynthesisOutputFormat {
     /// Raw8Khz8BitMonoMULaw stands for raw-8khz-8bit-mono-mulaw
     Raw8Khz8BitMonoMULaw = 1,


### PR DESCRIPTION
Hi, @Vocinity!

Thanks for your fork. This is a lot of saving hours for integrating the API with MacOSx services.

In my usecases, it would be very usefull to have the derives provided in this PR to use `SpeechSynthesisOutputFormat` as a key in maps and hashmaps.

Could you please consider the changes to pull to upstream?